### PR TITLE
next bpaf prerelease

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,13 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0.45"
-bpaf = "0.5.0"
+bpaf = { version = "0.5.0", features = ["autocomplete"] }
 toml = "0.5.8"
 serde = "1.0.130"
 tempfile = "3.3.0"
 colored = "2.0.0"
+
+
+[patch.crates-io]
+bpaf = { git = 'https://github.com/pacak/bpaf', branch = "rc-0.5.5"  }
+#bpaf = { path = "/home/pacak/ej/bpaf/" }

--- a/src/app.rs
+++ b/src/app.rs
@@ -137,10 +137,30 @@ fn remove_task_command() -> OptionParser<Command> {
         .descr("remove a task from a project")
 }
 
+fn complete_indices(input: &Vec<String>) -> Vec<(String, Option<String>)> {
+    let p = tutel::load_project_rec(&*std::env::current_dir().unwrap()).unwrap();
+    let mut res = Vec::new();
+
+    let full = &input[..input.len() - 1];
+    let active = input.last().unwrap();
+
+    for task in p.data.tasks {
+        let tid = task.index.to_string();
+        if full.contains(&tid) {
+            continue;
+        }
+        if tid.starts_with(active) {
+            res.push((format!("{}", task.index), Some(task.desc.clone())));
+        }
+    }
+
+    res
+}
+
 fn parse_indices() -> impl Parser<TaskSelector> {
     positional("indices")
-        .many()
-        .guard(|v| !v.is_empty(), "one or more task indices are required")
+        .some("one or more task indices are required")
+        .complete(complete_indices)
         .parse::<_, _, String>(|v| {
             let mut indices = Vec::with_capacity(v.len());
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -14,7 +14,7 @@ use std::{
 pub struct Project {
     pub path: PathBuf,
     pub steps: usize,
-    data: ProjectData,
+    pub data: ProjectData,
 }
 
 impl Project {
@@ -179,7 +179,7 @@ impl Display for Project {
 #[derive(Debug)]
 pub struct ProjectData {
     pub(crate) name: String,
-    pub(crate) tasks: Vec<Task>,
+    pub tasks: Vec<Task>,
 }
 
 /// A completable Task within a Project

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,9 +36,9 @@ fn run_app(command: Command) -> Result<()> {
         Command::Show => print_list(),
         Command::NewProject { name, force } => new_project(name, force),
         Command::AddTask { desc, completed } => add(desc, completed),
-        Command::MarkCompletion(selector, completed) => done(selector, completed),
+        Command::MarkCompletion(completed, selector) => done(selector, completed),
         Command::RemoveTask(selector) => remove(selector),
-        Command::EditTask(index, editor) => edit_task(index, editor),
+        Command::EditTask(editor, index) => edit_task(index, editor),
         Command::PrintCompletion(shell) => print_completions(shell.as_str()),
         Command::RemoveProject => remove_project(),
     }


### PR DESCRIPTION
I added support for autocomplete, not published yet, but I ~~need a victim~~  can use some feedback.

You can generate completion scripts like so:
```console
$ your_program --bpaf-complete-style-bash >> ~/.bash_completion
$ your_program --bpaf-complete-style-zsh > ~/.zsh/_your_program
$ your_program --bpaf-complete-style-fish > ~/.config/fish/completions/your_program.fish
```

and it gets you static completion for arguments - that replaces contents of the res folder.

Additionally it supports dynamic completion - for example anywhere you expect indices you can press tab and it will give you all the active TODO items. - try typing `tutel done <TAB>` in a folder with some items.

Current implementation of `complete_indices` is wrong, only to show the idea. I'd code it something like

- if input is empty - display first (or last) N todo items, if there are inputs present - split it into two parts: last item (one being completed) and the rest (items user already gave and cursor is not touching them).

Anyway. You can subtract already added items from the output, and filter the rest of the task ids by ids being prefix of the current one:
suppose you have tasks 1, 2, 3, 11, 12, 13, 20, 30 and vector contains ["1", "3", "12", "1"] this means user already specified 1/3/12 - no need to show them again, and the current item starts with 1 - so completion suggestions should contain "11" and "13".
Just realized API is insufficiently exposed - you can't tell if user is still entering "1" or it's something like "1 _" where _ is the cursor... Will push an update.

Feel free to poke around, any feedback will be appreciated.

Also - are you familiar with writing completions for elv shell? I need a template similar to bash/zsh/fish.