### PR TITLE
chore: Minor change to remove www from github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.2.10"
 edition = "2018"
 description = "a minimalistic todo app for terminal enthusiasts"
 authors = ["Arthur Wienstroer"]
-homepage = "https://www.github.com/0x5a4/tutel"
-repository = "https://www.github.com/0x5a4/tutel"
+homepage = "https://github.com/0x5a4/tutel"
+repository = "https://github.com/0x5a4/tutel"
 license = "MIT"
 categories = ["command-line-utilities"]
 


### PR DESCRIPTION
GitHub redirects to the address without www anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/96